### PR TITLE
feat(ci): add deploy pipeline with automated minification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Zola
+        run: |
+          curl -sL https://github.com/getzola/zola/releases/download/v0.21.0/zola-v0.21.0-x86_64-unknown-linux-gnu.tar.gz \
+            | tar xz -C /usr/local/bin
+
+      - name: Build site
+        run: zola build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,38 @@
-name: Build and deploy GH Pages
-on: push
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v3.0.0
-      - name: build_and_deploy
-        uses: shalzz/zola-deploy-action@v0.17.2
-        env:
-          PAGES_BRANCH: gh-pages
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+
+      - name: Install Zola
+        run: |
+          curl -sL https://github.com/getzola/zola/releases/download/v0.21.0/zola-v0.21.0-x86_64-unknown-linux-gnu.tar.gz \
+            | tar xz -C /usr/local/bin
+
+      - name: Build site
+        run: zola build
+
+      - name: Minify HTML / CSS / JS
+        run: |
+          curl -sL https://github.com/tdewolff/minify/releases/latest/download/minify_linux_amd64.tar.gz \
+            | tar xz -C /usr/local/bin minify
+          find public -name "*.html" -exec minify --type=html -o {} {} \;
+          find public -name "*.css" -not -name "*.min.css" -exec minify --type=css -o {} {} \;
+          find public -name "*.js"  -not -name "*.min.js"  -exec minify --type=js  -o {} {} \;
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: gh-pages

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ default:
   just --list
 
 install:
-  brew install zola
+  brew install zola minify
 
 build:
   zola build
@@ -23,7 +23,12 @@ optimize_media:
   gs -sDEVICE=pdfwrite -dNOPAUSE -dQUIET -dBATCH -dPDFSETTINGS=/screen -dCompatibilityLevel=1.4 -sOutputFile=output.pdf input.pdf
 
 minify:
-  ...
+  #!/usr/bin/env bash
+  set -euo pipefail
+  command -v minify >/dev/null 2>&1 || { echo "minify not found. Install with: brew install minify"; exit 1; }
+  find public -name "*.html" -exec minify --type=html -o {} {} \;
+  find public -name "*.css" -not -name "*.min.css" -exec minify --type=css -o {} {} \;
+  find public -name "*.js" -not -name "*.min.js" -exec minify --type=js -o {} {} \;
 
 PANDOC_INPUT := "publications/pandoc-input.md"
 OUTPUT_HTML := "out/list.html"
@@ -36,5 +41,16 @@ bib2html:
 notebook2markdown path:
   jupyter-nbconvert --to markdown {{path}}
 
-deploy:
-
+deploy: build minify
+  #!/usr/bin/env bash
+  set -euo pipefail
+  WORKTREE=$(mktemp -d)
+  trap "git worktree remove --force '$WORKTREE' 2>/dev/null || true" EXIT
+  git fetch origin gh-pages
+  git worktree add "$WORKTREE" gh-pages
+  rsync -a --delete --exclude='.git' public/ "$WORKTREE/"
+  git -C "$WORKTREE" add -A
+  git -C "$WORKTREE" diff --cached --quiet \
+    || git -C "$WORKTREE" commit -m "deploy: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+  git -C "$WORKTREE" push origin gh-pages
+  echo "Deployed to gh-pages."


### PR DESCRIPTION
- Update deploy.yml to trigger only on push to main (+ manual dispatch)
- Upgrade Zola from 0.17.2 to 0.21.0
- Add HTML/CSS/JS minification step via tdewolff/minify in CI
- Switch deployment to peaceiris/actions-gh-pages@v4
- Add build.yml PR check: verifies zola build passes on every PR to main
- Add justfile minify recipe (local tdewolff/minify CLI)
- Add justfile deploy recipe (build + minify + git worktree push to gh-pages)