### PR TITLE
feat(tooling): add typos spell checker to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.30.2
+    hooks:
+      - id: typos
+        args: [--write-changes]
+        types_or: [markdown]

--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # My personal website
 
-## Tech:
+## Tech
 
 - [Zola](https://www.getzola.org/)
 
-## TODO:
+## Tooling
+
+- **Formatter:** `just format` — runs prettier (CSS/JS/JSON/MD), taplo (TOML), markdownlint-cli2 (Markdown), bibtex-tidy (BibTeX)
+- **Spell checker:** typos — auto-fixes typos in Markdown files via pre-commit
+- **Pre-commit:** `just install` registers all hooks; runs on every commit and on PRs to `main`
+- **Deploy:** `just deploy` — builds, minifies HTML/CSS/JS, pushes to `gh-pages`
+
+## TODO
 
 - [x] Publications
 - [x] Social links
+- [x] Internationalization
+- [x] Spell checker
 - [ ] Dark mode/light mode button
-- [ ] Internationalization
-- [ ] Spell checker
 - [ ] Blog: From Zero

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,6 @@
+[files]
+extend-exclude = ["*.bib", "public/"]
+
+[default.extend-words]
+# Add project-specific words that should not be flagged, e.g.:
+# "ND" = "ND"


### PR DESCRIPTION
- Add typos (https://github.com/crate-ci/typos) pre-commit hook targeting Markdown files with --write-changes to auto-fix typos on commit
- Add _typos.toml config: exclude .bib files and public/ from checks; extend-words table available for project-specific false-positive overrides
- Update README: mark Internationalization and Spell checker as done, add Tooling section documenting formatter, spell checker, pre-commit, deploy