### PR TITLE
fix: add CNAME to preserve custom domain on deploy

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+edadaltocg.com


### PR DESCRIPTION
 GitHub Pages stores the custom domain as a `CNAME` file at the root of the
  `gh-pages` branch. Every CI deploy was overwriting the branch and deleting
  that file, causing the custom domain to disappear.

  Adding `static/CNAME` makes Zola include it in `public/` on every build,
  so it is always present in the deployed output.

  ## Test plan

  - [ ] Merge and trigger a deploy — verify `edadaltocg.com` remains set in
    GitHub Pages settings after the workflow completes
